### PR TITLE
Addresses issue #3 by adding support for multiple "mshtml.dll" versions

### DIFF
--- a/Gargoyle.vcxproj
+++ b/Gargoyle.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{76CDDD0D-EA56-4AA9-9B94-41390A34AB23}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Gargoyle</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -73,6 +73,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>version.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
In order to allow people with different versions of Windows and/or the "mshtml.dll" file to try this out, I added a lookup table that maps an "mshtml.dll" version to the offset of its ROP gadget.  I added an entry for the version that I am using.  Since, I don't know what version of the "mshtml.dll" file that the original author was using, I left the default as it was for unrecognized versions of the "mshtml.dll" file.

A better solution would be to search for the ROP gadget bytes either in memory or in the "mshtml.dll" file on disk.  Maybe this implementation would be even easier, but it requires some knowledge that I didn't readily have available.  In particular, I think it is necessary to not only get the "mshtml.dll" base address but also to work out how it was mapped into memory.  I assume that it is not necessarily the case that all segments are mapped contiguously.  Further, it is necessary to know where the last segment ends.  Similarly, if searching the file on disk it is necessary to understand how positions in the file ultimately will get mapped into memory.

My C, C++, and Windows API programming is a bit rusty, so I don't have any complaints if some adjustments are desired.