### PR TITLE
docs: prepare refresh notes for retrospective blog

### DIFF
--- a/.agent/PLANS.md
+++ b/.agent/PLANS.md
@@ -17,6 +17,87 @@ without reading the full chat.
 
 ## Active Plans
 
+### Plan: Issue #24 Pre-Blog Gargoyle Refresh Readiness
+
+#### Objective
+
+Prepare a small documentation-focused PR that makes the 2026 Gargoyle refresh easy to cite
+before drafting a retrospective blog post.
+
+Definition of done:
+
+- GitHub issue #24 tracks the pre-blog readiness work.
+- Branch `codex/blog-refresh-readiness` contains only scoped documentation, planning, and
+  private-ignore changes.
+- Public docs include a `2026 Refresh` page summarizing the refresh arc, architecture claims,
+  the `SleepEx` APC semantics fix, validation evidence, and explicit non-goals.
+- `mkdocs.yml`, `docs/index.md`, and `README.md` link the new page.
+- `.private-docs/` remains ignored, with private evidence notes updated outside the commit.
+- PR opens against `master`, stops short of merge, and has passing local validation and CI.
+
+#### User Decisions And Assumptions
+
+User decisions:
+
+- 2026-05-11: User asked to implement the approved pre-blog readiness plan with an issue,
+  branch, and PR.
+
+Assumptions:
+
+- This is a documentation-readiness pass, not a new native runtime feature.
+- The PR should not add detector tooling, gadget search, PE wrapping, injection tooling, or
+  payload mechanics.
+- The tone should stay historical, reflective, benign, and defender-aware.
+
+#### Scope
+
+In scope:
+
+- `docs/refresh-2026.md`, docs navigation, README documentation list, `.gitignore`, and this
+  plan file.
+- Ignored private evidence notes under `.private-docs/gargoyle-research/`.
+- GitHub issue, branch, commit, PR, and CI shepherding.
+
+Out of scope:
+
+- Native behavior changes.
+- Offensive tooling expansion.
+- Merging the PR.
+
+#### Validation
+
+Planned local checks:
+
+- `just docs` passed on 2026-05-11.
+- `just check` passed on 2026-05-11.
+
+GitHub checks:
+
+- PR run `25699863387` passed `Windows build and Python checks` and
+  `Windows 11 ARM smoke` on 2026-05-11.
+
+#### Artifact Index
+
+- Issue #24: `https://github.com/JLospinoso/gargoyle/issues/24`
+- Branch: `codex/blog-refresh-readiness`
+- PR #25: `https://github.com/JLospinoso/gargoyle/pull/25`
+
+#### Progress Log
+
+- 2026-05-11: Issue #24 created and branch `codex/blog-refresh-readiness` created.
+- 2026-05-11: Started docs implementation.
+- 2026-05-11: Added `docs/refresh-2026.md`, linked it from MkDocs, README, and docs
+  index, and confirmed `.private-docs/` ignores the private evidence log.
+- 2026-05-11: Local validation passed with `just docs` and `just check`.
+- 2026-05-11: Commit `28655c2` pushed and PR #25 opened against `master`.
+- 2026-05-11: Amended branch to commit `2f911b0` with PR metadata; PR run
+  `25699863387` passed both required checks.
+
+#### Handoff Packet
+
+- Current status: PR #25 is open, validated, and ready for review/merge.
+- Remaining: none for this plan unless the PR receives review feedback.
+
 ### Plan: Timer APC Re-Entry Semantics Fix
 
 #### Objective

--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,6 @@ site/
 dist/
 asan/
 
+# Private planning and research notes
+.private-docs/
+

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Every 15 seconds, gargoyle will pop up a message box. When you click ok, gargoyl
 
 The refreshed documentation includes:
 
+* `docs/refresh-2026.md` for a pre-retrospective summary of the refresh, architecture claims, corrected APC evidence, and non-goals.
 * `docs/acceptance.md` for the Python acceptance harness.
 * `docs/validation-checklist.md` for automated and manual runtime checks.
 * `docs/win32-architecture.md` for the current Win32 configuration, stack, timer/APC, gadget, and protection-cycle layout.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,9 @@ Gargoyle is a small Windows proof of concept for memory-scanner evasion.
 
 The 2026 refresh keeps the original Win32 artifact intact while adding modern
 build tooling, acceptance validation, documentation, and a sibling x64
-timer/APC example.
+timer/APC example. Start with [2026 Refresh](refresh-2026.md) for the
+pre-retrospective summary of what changed, what each architecture proves, and
+what the repository intentionally does not claim.
 
 ## Developer Commands
 

--- a/docs/refresh-2026.md
+++ b/docs/refresh-2026.md
@@ -1,0 +1,64 @@
+# 2026 Refresh
+
+The 2026 refresh keeps Gargoyle's original Win32 proof of concept recognizable
+while making it easier to build, validate, and discuss as a historical research
+artifact. The goal is not to turn the repository into a broader payload
+framework. The goal is to preserve the original lesson, document what changed,
+and make the evidence clear enough for a retrospective post.
+
+## What Changed
+
+- Added a Python acceptance harness with build discovery, artifact checks,
+  platform-aware setup-banner parsing, live MessageBox validation, and
+  non-interactive modes for CI-safe evidence.
+- Added a sibling x64 example that uses pointer-sized configuration, Win64 ABI
+  calls from PIC, and a separate executable re-entry PIC instead of replacing
+  the Win32 stack-pivot design.
+- Added ARM64 and ARM64EC sibling projects so hosted Windows-on-Arm CI can prove
+  build identity, PE machine type, architecture reporting, and benign headless
+  timer/APC rounds.
+- Corrected the timer/APC proof to use `SleepEx(INFINITE, TRUE)` for re-entry
+  waits, which ties the second round to APC delivery instead of timer-handle
+  signaled state.
+- Added strict documentation, Python checks, native MSVC analysis, AddressSanitizer
+  builds, and GitHub Actions coverage around the refreshed examples.
+- Added responsible-use, validation, architecture, reference, and future-work
+  documentation so later discussion stays historical, reproducible, and
+  defender-aware.
+
+## Architecture Claims
+
+| Architecture | What It Proves | Validation Path | Caveat |
+| --- | --- | --- | --- |
+| x86 | The original Win32 reference path still demonstrates the ROP/APC/protection-cycle baseline. | Live acceptance builds `Debug|x86` or `Release|x86`, parses the setup banner, and closes two benign `gargoyle` MessageBoxes. | This remains the historical shape and intentionally keeps the compact 32-bit stack-pivot design. |
+| x64 | The sibling x64 example demonstrates timer/APC re-entry and protection cycling with pointer-sized configuration and Win64 ABI calls. | Live acceptance builds `Debug|x64` or `Release|x64`, validates x64 artifacts, parses setup and re-entry addresses, and closes two benign `gargoyle x64` MessageBoxes. | It is not a transparent port of the original x86 stack-pivot chain; it uses a separate re-entry PIC. |
+| ARM64 | The native Windows-on-Arm example builds and runs short benign timer/APC rounds on hosted ARM64 Windows. | `windows-11-arm` CI builds ARM64 Debug/Release, checks PE machine identity, runs architecture reports, and runs headless rounds without GUI automation. | Desktop live validation still depends on ARM64 Windows hardware or an equivalent local lab. |
+| ARM64EC | The ARM64EC example proves build/runtime identity, EC dynamic-code allocation, architecture reporting, and APC semantics in an ARM64EC process. | `windows-11-arm` CI builds ARM64EC Debug/Release, checks ARM64EC-compatible image identity, runs architecture reports, and runs headless rounds. | Version 1 does not demonstrate mixed x64 DLL interop; it keeps ARM64EC focused on identity and runtime semantics. |
+
+## Why The SleepEx Fix Matters
+
+The original wait shape could wake because the timer object became signaled,
+even if the completion routine had not yet run. That made a successful-looking
+second round weaker evidence than intended.
+
+The refreshed implementation arms the waitable timer and then enters an
+alertable `SleepEx(INFINITE, TRUE)` wait. In this shape, progress through the
+re-entry path is tied to APC delivery. The demos still remain benign and visible,
+but the proof now better matches the claim: timer/APC re-entry is what drives the
+next round.
+
+## What This Does Not Claim
+
+- It does not make Gargoyle a general loader, operator workflow, or stealth
+  framework.
+- It does not claim that x64, ARM64, or ARM64EC reproduce every detail of the
+  original Win32 stack-pivot chain.
+- It does not claim to defeat modern endpoint products or platform mitigations.
+- It does not add credential access, persistence, deployment, networking, or
+  non-benign payload behavior.
+- It does not treat platform failures or detections as bypass problems. Those
+  outcomes are research data and should be documented.
+
+The useful retrospective claim is narrower and more durable: Gargoyle made
+memory scanning a temporal problem. The refresh makes that lesson easier to
+rebuild, observe, and cite across modern Windows architectures.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - 2026 Refresh: refresh-2026.md
   - Acceptance Harness: acceptance.md
   - Validation Checklist: validation-checklist.md
   - Win32 Architecture: win32-architecture.md


### PR DESCRIPTION
Closes #24

## Summary
- add a public 2026 refresh page that summarizes the build/tooling refresh, x64 sibling, ARM64/ARM64EC parity, corrected `SleepEx` APC semantics, validation evidence, and responsible-use boundaries
- wire the refresh page into MkDocs, the docs index, and the README documentation list

## Notes
- This is documentation-only.
- There are no runtime, demo-action, or native behavior changes.

## Validation
- `just docs`
- `just check`
- GitHub Actions passed `Windows build and Python checks` and `Windows 11 ARM smoke`